### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kblackbox.json
+++ b/org.kde.kblackbox.json
@@ -12,6 +12,14 @@
         "--share=network",
         "--device=dri"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/qml",
+        "/share/carddecks",
+        "/share/doc",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         {
             "name": "libkdegames",


### PR DESCRIPTION
KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.

This PR also removes the /share/carddecks folder, which is not required for this game.